### PR TITLE
TESTING 2 -- ci: cancel previous workflows when branch is updated

### DIFF
--- a/.github/workflows/ci-cancel.yml
+++ b/.github/workflows/ci-cancel.yml
@@ -1,13 +1,17 @@
-# Cancel previous CI workflow when the branch that triggered it is updated
+# Cancel previous CI workflows that are still running when a new one is
+# requested with the same ID. Happens when a branch is pushed to,
+# including when a PR is updated. It would be wasteful to leave CI
+# running on obsolete content.
 # See https://github.com/marketplace/actions/cancel-workflow-action#advanced-pull-requests-from-forks
 name: Cancel CI
 on:
   workflow_run:
     workflows: [CI]
     types: [requested]
+    branches-ignore: [master]
 jobs:
   cancel:
-    name: Cancel previous CI workflow
+    name: Cancel CI workflows
     runs-on: ubuntu-latest
     steps:
     - uses: styfle/cancel-workflow-action@0.10.0

--- a/.github/workflows/ci-cancel.yml
+++ b/.github/workflows/ci-cancel.yml
@@ -1,4 +1,3 @@
-#
 # Cancel previous CI workflows that are still running when a new one is
 # requested with the same ID. Happens when a branch is pushed to,
 # including when a PR is updated. It would be wasteful to leave CI

--- a/.github/workflows/ci-cancel.yml
+++ b/.github/workflows/ci-cancel.yml
@@ -1,3 +1,4 @@
+#
 # Cancel previous CI workflows that are still running when a new one is
 # requested with the same ID. Happens when a branch is pushed to,
 # including when a PR is updated. It would be wasteful to leave CI


### PR DESCRIPTION
When commits are pushed to a branch, the CI workflow is triggered.
However in most cases (development branches, pull requests) we don't
want previous jobs to keep running; it is just wasteful of resources.
Therefore add a special workflow to deal with the situation [1].

An exception is made for pushes to the master branch, otherwise nothing
might get build for a long time if many updates are made back-to-back.

Link: [1] https://github.com/marketplace/actions/cancel-workflow-action#advanced-pull-requests-from-forks
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
